### PR TITLE
fix: correct tabs usage to address exception 

### DIFF
--- a/tools/debug/src/lib.rs
+++ b/tools/debug/src/lib.rs
@@ -157,13 +157,13 @@ impl ImguiRenderLoop for EldenRingDebugGui {
                     render_debug_singleton::<CSFeManImp>(&ui);
                     item.end();
                 }
-                tabs.end();
                 if let Some(item) = ui.tab_item("Eject") {
                     if ui.button("Eject") {
                         eject();
                     }
                     item.end();
                 }
+                tabs.end();
             });
     }
 }


### PR DESCRIPTION
# Problem 
[Exception produced by adding tab_item after tabs.end()](https://github.com/vswarte/eldenring-rs/issues/58)

# Solution
Call tabs.end() only after every tab_item has been called